### PR TITLE
refactor(pipelines): make production view less friendly

### DIFF
--- a/src/airtable.model.ts
+++ b/src/airtable.model.ts
@@ -234,7 +234,7 @@ export interface AirtableTableCfg<T extends AirtableRecord = any> {
   sort?: AirtableApiSort<T>[]
 
   /**
-   * @default 'Grid view'
+   * @default 'PRODUCTION_DO_NOT_TOUCH'
    * Without view - airtable api returns records in wrongly sorted order (sorted by airtableId), not in the view order.
    */
   view?: string

--- a/src/airtableDB.ts
+++ b/src/airtableDB.ts
@@ -298,7 +298,7 @@ export class AirtableDB extends BaseCommonDB implements CommonDB {
       .select({
         // defaults
         pageSize: 100,
-        view: 'Grid view',
+        view: 'PRODUCTION_DO_NOT_TOUCH',
         // ...(sort?.length && { sort }),
         ...selectOpts,
       })

--- a/src/airtableTableDao.ts
+++ b/src/airtableTableDao.ts
@@ -43,7 +43,7 @@ export class AirtableTableDao<T extends AirtableRecord = any> implements Instanc
       .select({
         // defaults
         pageSize: 100,
-        view: this.cfg.view || 'Grid view',
+        view: this.cfg.view || 'PRODUCTION_DO_NOT_TOUCH',
         ...(sort?.length && { sort }),
         ...selectOpts,
       })


### PR DESCRIPTION
I was thinking that renaming the view to something unfriendly, react style, and putting it at the bottom with a duplicate view at the top would make things less error-prone. This hasn't been done yet in airtable so it's not safe to merge yet.

This implementation is not safe and I'm redoing it, it shouldn't be done as default, but in the cfg for product specifically since we only want it there I just realized
